### PR TITLE
resize mbox prefetch if greater than 1000 bytes

### DIFF
--- a/mbox.go
+++ b/mbox.go
@@ -197,7 +197,12 @@ func (m *MboxStream) nextLine() error {
 	if err != nil {
 		return err
 	}
-	m.prefetch = m.prefetch[0:len(slice)]
+	// If slice is longer than the original prefetch, resize.
+	if len(slice) <= cap(m.prefetch) {
+		m.prefetch = m.prefetch[0:len(slice)]
+	} else {
+		m.prefetch = make([]byte, len(slice))
+	}
 	copy(m.prefetch, slice)
 	m.prefetchLength = len(m.prefetch)
 	m.currentLine++


### PR DESCRIPTION
We have cases where a line is longer than 1000 bytes, which we would like to allow by conditionally resizing prefetch. Without this change, it panics.